### PR TITLE
new-redirect

### DIFF
--- a/src/common/helpers/redirectHelper.js
+++ b/src/common/helpers/redirectHelper.js
@@ -31,10 +31,11 @@ export const checkAppStatus = async host => {
   const statusInfo = await getSiteStatusInfo(host);
 
   if (!statusInfo.status) {
-    return { redirect: true, redirectPath: notFoundRedirectPath(host) };
+    return { redirect: true, status: 301, redirectPath: notFoundRedirectPath(host) };
   }
+
   if (statusInfo.status !== 'active') {
-    return { redirect: true, redirectPath: `https://${statusInfo.parentHost}` };
+    return { redirect: true, status: 307, redirectPath: `https://${statusInfo.parentHost}` };
   }
 
   return { redirect: false };

--- a/src/server/handlers/createSsrHandler.js
+++ b/src/server/handlers/createSsrHandler.js
@@ -66,8 +66,8 @@ export default function createSsrHandler(template) {
     const inheritedHost = isInheritedHost(hostname);
 
     if (inheritedHost) {
-      const { redirect, redirectPath } = await checkAppStatus(hostname);
-      if (redirect) return res.redirect(301, redirectPath);
+      const { redirect, redirectPath, status } = await checkAppStatus(hostname);
+      if (redirect) return res.redirect(status, redirectPath);
     }
 
     if (req.url.includes('/checklist/'))


### PR DESCRIPTION
Fixes #

Changes

Changed HTTP redirect status code from 301 Moved Permanently to 307 Temporary Redirect for inactive sites to ensure request methods are preserved.
Test plan

Verify that inactive site URLs now return a 307 Temporary Redirect instead of 301.
Confirm that request methods (e.g., POST, PUT) are maintained across redirects.
Check browser and network responses to ensure correct behavior.

